### PR TITLE
docs: fix simple typo, happends -> happens

### DIFF
--- a/src/shaders/fxaa3_11.h
+++ b/src/shaders/fxaa3_11.h
@@ -149,7 +149,7 @@ Getting luma correct is required for the algorithm to work correctly.
                           BEING LINEARLY CORRECT?
 ------------------------------------------------------------------------------
 Applying FXAA to a framebuffer with linear RGB color will look worse.
-This is very counter intuitive, but happends to be true in this case.
+This is very counter intuitive, but happens to be true in this case.
 The reason is because dithering artifacts will be more visiable
 in a linear colorspace.
 


### PR DESCRIPTION
There is a small typo in src/shaders/fxaa3_11.h.

Should read `happens` rather than `happends`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md